### PR TITLE
Implement a different way to deal with patient-level labels

### DIFF
--- a/config/pre-training/extract_features.yaml
+++ b/config/pre-training/extract_features.yaml
@@ -1,4 +1,4 @@
-region_dir: '/home/user/code/git/cpg/hs2p/output/tcga_brca_subtyping_4096/patches'
+region_dir: '/home/user/code/git/cpg/hs2p/output/panda_dino/patches/2048/jpg'
 
 output_dir: 'output'
 experiment_name: 'dino'
@@ -6,13 +6,13 @@ resume: False
 
 slide_list:
 
-region_size: 4096
+region_size: 2048
 patch_size: 256
 mini_patch_size: 16
 
-format: 'png'
+format: 'jpg'
 
-pretrain_vit_patch: 'output/dino/dino/checkpoint.pth'
+pretrain_vit_patch: 'checkpoints/vit_256_small_dino.pth'
 freeze_vit_patch: True
 
 wandb:

--- a/config/pre-training/patch.yaml
+++ b/config/pre-training/patch.yaml
@@ -1,6 +1,6 @@
 data_dir: '/data/pathology/projects/ais-cap/code/git/clemsgrs/hipt/data/panda_radboud/dino/patch_256_pretraining'
 output_dir: '/data/pathology/projects/ais-cap/code/git/clemsgrs/hipt/output/panda_radboud'
-experiment_name: 'dino'
+experiment_name: 'dino_patch'
 
 resume: False
 resume_from_ckpt: 'latest'

--- a/config/training/survival/multi.yaml
+++ b/config/training/survival/multi.yaml
@@ -3,11 +3,11 @@ defaults:
   - _self_
 
 data:
-  fold_dir: '/data/pathology/projects/ais-cap/dataset/tcga/brca/survival/5fold-cv'
+  fold_dir: '/data/pathology/projects/ais-cap/dataset/tcga/brca/survival/5fold-cv_narrowed'
 
 features_dir: '/data/pathology/projects/ais-cap/code/git/cpg/hipt/output/tcga_brca_all_slides/features/global'
 # features_dir: '/home/user/code/git/opensource/HIPT/3-Self-Supervised-Eval/embeddings_slide_lib/embeddings_slide_lib/vit256mean_tcga_slide_embeddings'
-experiment_name: 'tcga_brca_survival_multifold'
+experiment_name: 'tcga_brca_survival_narrowed_multifold_patient_agg'
 level: 'global'
 
 nepochs: 50

--- a/config/training/survival/single.yaml
+++ b/config/training/survival/single.yaml
@@ -31,13 +31,14 @@ model:
   pretrain_vit_patch: 'checkpoints/vit_256_small_dino.pth'
   freeze_vit_patch: True
   freeze_vit_patch_pos_embed: True
-  mini_patch_size: 16
   pretrain_vit_region: 'checkpoints/vit_4096_xs_dino.pth'
   freeze_vit_region: True
   freeze_vit_region_pos_embed: True
   region_size: 4096
   patch_size: 256
+  mini_patch_size: 16
   dropout: 0.25
+  agg_method: "concat"
 
 optim:
   name: 'adam'

--- a/pre-train/extract_features.py
+++ b/pre-train/extract_features.py
@@ -71,7 +71,7 @@ def main(cfg: DictConfig):
     total = len(process_stack)
     already_processed = len(df) - total
 
-    region_dataset = RegionFilepathsDataset(df, region_dir, cfg.region_size, cfg.format)
+    region_dataset = RegionFilepathsDataset(df, region_dir, cfg.format)
     region_subset = torch.utils.data.Subset(
         region_dataset, indices=process_stack.index.tolist()
     )

--- a/train/survival_multi.py
+++ b/train/survival_multi.py
@@ -14,7 +14,7 @@ from omegaconf import DictConfig
 
 from source.models import ModelFactory
 from source.components import LossFactory
-from source.dataset import ExtractedFeaturesSurvivalDataset, ppcess_tcga_survival_data
+from source.dataset import ExtractedFeaturesSurvivalDataset, ExtractedFeaturesPatientLevelSurvivalDataset, ppcess_tcga_survival_data
 from source.utils import (
     initialize_wandb,
     train_survival,
@@ -79,6 +79,7 @@ def main(cfg: DictConfig):
         if cfg.training.pct:
             print(f"Training on {cfg.training.pct*100}% of the data")
             dfs["train"] = dfs["train"].sample(frac=cfg.training.pct).reset_index(drop=True)
+
         train_tune_df = pd.concat([df for df in dfs.values()], ignore_index=True)
         patient_df, slide_df = ppcess_tcga_survival_data(train_tune_df, cfg.label_name, nbins=cfg.nbins)
 
@@ -87,15 +88,26 @@ def main(cfg: DictConfig):
             patient_dfs[partition] = patient_df[patient_df.partition == partition].reset_index(drop=True)
             slide_dfs[partition] = slide_df[slide_df.partition == partition]
 
-        train_dataset = ExtractedFeaturesSurvivalDataset(
-            patient_dfs["train"], slide_dfs["train"], features_dir, cfg.label_name,
-        )
-        tune_dataset = ExtractedFeaturesSurvivalDataset(
-            patient_dfs["tune"], slide_dfs["tune"], features_dir, cfg.label_name,
-        )
-        test_dataset = ExtractedFeaturesSurvivalDataset(
-            patient_dfs["tune"], slide_dfs["tune"], features_dir, cfg.label_name,
-        )
+        if cfg.model.agg_method == 'concat':
+            train_dataset = ExtractedFeaturesSurvivalDataset(
+                patient_dfs["train"], slide_dfs["train"], features_dir, cfg.label_name,
+            )
+            tune_dataset = ExtractedFeaturesSurvivalDataset(
+                patient_dfs["tune"], slide_dfs["tune"], features_dir, cfg.label_name,
+            )
+            test_dataset = ExtractedFeaturesSurvivalDataset(
+                patient_dfs["tune"], slide_dfs["tune"], features_dir, cfg.label_name,
+            )
+        elif cfg.model.agg_method == 'self_att':
+            train_dataset = ExtractedFeaturesPatientLevelSurvivalDataset(
+                patient_dfs["train"], slide_dfs["train"], features_dir, cfg.label_name,
+            )
+            tune_dataset = ExtractedFeaturesPatientLevelSurvivalDataset(
+                patient_dfs["tune"], slide_dfs["tune"], features_dir, cfg.label_name,
+            )
+            test_dataset = ExtractedFeaturesPatientLevelSurvivalDataset(
+                patient_dfs["tune"], slide_dfs["tune"], features_dir, cfg.label_name,
+            )
 
         model = ModelFactory(cfg.level, cfg.nbins, cfg.model).get_model()
         model.relocate()
@@ -144,6 +156,7 @@ def main(cfg: DictConfig):
                     train_dataset,
                     optimizer,
                     criterion,
+                    agg_method=cfg.model.agg_method,
                     batch_size=cfg.training.batch_size,
                     gradient_accumulation=cfg.training.gradient_accumulation,
                 )
@@ -159,6 +172,7 @@ def main(cfg: DictConfig):
                         model,
                         tune_dataset,
                         criterion,
+                        agg_method=cfg.model.agg_method,
                         batch_size=cfg.tuning.batch_size,
                     )
 
@@ -217,6 +231,7 @@ def main(cfg: DictConfig):
         test_results = test_survival(
             model,
             test_dataset,
+            agg_method=cfg.model.agg_method,
             batch_size=1,
         )
         test_dataset.patient_df.to_csv(Path(result_dir, f"test.csv"), index=False)

--- a/train/survival_multi.py
+++ b/train/survival_multi.py
@@ -79,7 +79,6 @@ def main(cfg: DictConfig):
         if cfg.training.pct:
             print(f"Training on {cfg.training.pct*100}% of the data")
             dfs["train"] = dfs["train"].sample(frac=cfg.training.pct).reset_index(drop=True)
-
         train_tune_df = pd.concat([df for df in dfs.values()], ignore_index=True)
         patient_df, slide_df = ppcess_tcga_survival_data(train_tune_df, cfg.label_name, nbins=cfg.nbins)
 


### PR DESCRIPTION
when dealing with patient-level labels like survival labels, one may encounter cases where multiple slides are available for a given patient

in that case, instead of concatenating regions from multiple slides into a single -- longer -- input sequence, pool from region to slide-level representation for each slide independently, then feed the sequence of slide-level representation into another (a 4th) Transformer block to pool these into a single patient-level representation