### PR TITLE
add cox-based survival training via prediction accumulation

### DIFF
--- a/config/training/survival/coxph.yaml
+++ b/config/training/survival/coxph.yaml
@@ -1,0 +1,69 @@
+# Example continuous-time CoxPH survival training config.
+# Mirrors src/configs/default.yaml; override paths for your dataset.
+# Run: python -m src.train.survival --config-file config/training/survival/coxph.yaml
+
+data:
+  train_csv: "/path/to/train.csv"   # needs columns: case_id, <label_name>, censored
+  tune_csv: "/path/to/tune.csv"
+  test_csv:
+
+output_dir: "output"
+
+task: "survival"
+label_name: "survival_months"       # continuous event/censoring time column
+
+survival:
+  loss: "coxph"                     # selects the Cox path (default is "nll")
+  cox:
+    n: 48                           # prediction-accumulation window = risk-set size
+    ties: "breslow"                 # "breslow" or "efron" (passed to torchsurv)
+    event_balanced: true            # guarantee >= min_events events per window
+    min_events: 1
+
+# num_classes is forced to 1 for the Cox head; this value is ignored by the Cox path
+num_classes: 1
+
+metrics:
+  - "c-index"
+
+features_dir: "/path/to/precomputed/tile/features"
+features_dim: 1024
+
+model:
+  level: "global"
+
+training:
+  nepochs: 100
+  batch_size: 1                     # bags are variable-size, always 1
+  # gradient_accumulation is ignored by the Cox path (one step per window)
+
+tuning:
+  batch_size: 1
+  tune_every: 1
+
+testing:
+  retrieve_checkpoint: "best"
+
+optim:
+  name: "adam"
+  # one optimizer step per window (~n fewer updates/epoch than NLL) -> consider a
+  # higher lr and/or more epochs than the discrete-time NLL baseline
+  lr: 0.0002
+  wd: 1e-5
+  lr_scheduler:
+    name: "step"
+    step_size: 20
+    gamma: 0.5
+
+early_stopping:
+  enable: true
+  tracking: "loss"                  # full-cohort Cox loss (deterministic across epochs)
+  min_max: "min"
+  patience: 20
+  min_epoch: 50
+
+speed:
+  num_workers: 8
+
+wandb:
+  enable: false

--- a/cox-ph-trick.md
+++ b/cox-ph-trick.md
@@ -1,0 +1,207 @@
+# CoxPH Training with Prediction Accumulation for Variable-Size MIL Bags
+
+> Revised after design review. This supersedes the original proposal. Where this
+> document diverges from the naive approach, the reasoning is called out inline.
+
+## Goal
+
+Add an **opt-in** continuous-time CoxPH survival training mode for MIL aggregators,
+alongside the existing discrete-time NLL path (`NLLSurvLoss`). Each patient/slide
+bag is processed with `batch_size=1` (bags have variable tile counts), but the Cox
+partial-likelihood loss is computed over an effective mini-batch of multiple patients.
+
+The existing NLL path (`task == "survival"`, model outputs `[1, nbins]`, risk =
+`-sum(surv)`) is **left untouched**. Cox is purely additive.
+
+## Why prediction accumulation (and why NLL does *not* need it)
+
+The current `NLLSurvLoss` is **per-patient independent**: each patient contributes a
+self-contained loss term, so `batch_size=1` plus ordinary gradient accumulation
+already works. CoxPH is different — the partial likelihood couples patients through a
+**risk set** (each event's denominator sums over everyone still at risk). A single
+patient has no risk set, so standard gradient accumulation (one independent loss per
+microbatch) is meaningless for Cox.
+
+The fix: forward several single-patient bags, keep their **graph-connected** risk
+scalars, concatenate them, compute **one** Cox loss over the group, and backprop once.
+
+```python
+# correct pattern (one "window" = N forwards -> 1 cat -> 1 loss -> 1 backward)
+risks = []
+for _ in range(N):
+    risks.append(model(bag).view(1))   # NO detach / item / no_grad
+loss = cox_loss(torch.cat(risks), times, events)
+loss.backward()
+optimizer.step()
+```
+
+Do **not** call `.detach()`, `.item()`, `.cpu().numpy()`, or wrap the forward in
+`torch.no_grad()` during training — risk tensors must stay connected to their graph
+until `loss.backward()`.
+
+## Key design decisions (review outcomes)
+
+### 1. Use a library for the Cox loss — do not hand-roll it
+
+Use **`torchsurv`** (`torchsurv.loss.cox.neg_partial_log_likelihood`). It is pure
+PyTorch, differentiable, and handles tie approximations (Breslow / Efron) via a flag.
+This removes the need to implement sorting, `logcumsumexp`, and tie handling ourselves.
+
+- New dependency: pin `torchsurv==0.1.6` in requirements.
+- Keep `scikit-survival` (`sksurv`) for the C-index metric — it is numpy/CPU and not
+  differentiable, so it is for evaluation only, not the loss. Already in use in
+  `src/utils/metrics.py`; no change needed there beyond the sign note below.
+
+**Polarity trap:** the dataset yields `censored` (1 = censored). `torchsurv` expects
+`event` (1 = event). Pass `event = 1 - censored`. Verify the exact argument order and
+boolean/float expectations against the installed 0.1.6 API at implementation time — a
+flipped convention silently trains the model to rank survival backwards.
+
+**fp32:** compute the Cox loss in float32 even under AMP (numerical stability of the
+log-cumsum term).
+
+### 2. Risk-set is a random sub-cohort — accept the approximation, raise N
+
+Computing the Cox loss over an N-patient window optimizes an expectation over random
+N-patient sub-cohorts, not the full-cohort partial likelihood. The gradient is biased
+relative to full-cohort Cox; the bias shrinks as N grows. This is the standard
+"Cox loss on mini-batches" technique and is accepted here.
+
+Because tile features are **precomputed/frozen** and the aggregator is light, holding N
+forward-graphs is cheap, so prefer a **moderately large N (32–64)** rather than the
+small N=16 in the original draft. Larger N = larger risk set = less biased gradient.
+
+### 3. Event-balanced sampling — not "skip no-event windows"
+
+With random sampling and heavy censoring (common in pathology), some windows contain
+zero events and produce no gradient. The naive fix (compute the loss, then skip the
+window if `events.sum() == 0`) **wastes N forward passes** and **biases sampling** by
+systematically discarding the most-censored draws. (It also had dead code: a
+graph-connected zero-loss return that was never reached because the caller bailed
+before `backward()`.)
+
+Instead, use a **custom `BatchSampler`** that constructs each window to contain **≥1
+event** (ideally several). This eliminates wasted windows and lowers gradient variance.
+The sampler needs per-`idx` `censored` access from the dataset.
+
+### 4. Model head: single risk scalar
+
+When Cox is selected, build the model with `num_classes = 1` and use the raw scalar
+logit directly as the risk (higher = higher hazard / shorter survival). Assert
+`num_classes == 1` when the Cox loss is selected. Do **not** reuse the binned head or
+the `-sum(surv)` derivation — those belong to the NLL path only.
+
+### 5. Evaluation: full-cohort Cox loss, no accumulation
+
+Prediction accumulation exists only to bound **training** memory. At eval there is no
+backward pass and no graph to hold, so run all tune/test patients under
+`torch.no_grad()`, collect every risk scalar, and compute the Cox loss over the
+**entire cohort at once** — the true full risk set, which is *more* correct than
+training and **deterministic across epochs** (a clean early-stopping signal).
+
+Update the Cox branch of `tune` / `inference` accordingly:
+
+- **risk** = raw model output (no sigmoid / cumprod / surv).
+- **validation loss** = one `neg_partial_log_likelihood` over all tune patients.
+- **C-index** = `concordance_index_censored(event_indicator, event_time, risk)` —
+  unchanged call, but feed the **raw Cox risk** (higher = worse). Do not apply the
+  NLL `-sum(surv)` sign flip; that would double-invert.
+
+Early stopping continues to watch **tune loss** (`min`); under Cox this is the
+full-cohort partial likelihood.
+
+### 6. One accumulation axis only (Lever 1)
+
+Two orthogonal levers exist:
+
+- **Lever 1 — N (prediction accumulation):** number of forward-graphs held before one
+  backward = the risk-set size of a single Cox loss. Bounded by memory. **This is the
+  only lever that improves the risk-set approximation.**
+- **Lever 2 — gradient accumulation across windows (M):** run M separate windows, each
+  with its own Cox loss and `backward()`, summing `.grad` before one `optimizer.step()`.
+  This lowers gradient variance and reduces step frequency but does **not** enlarge the
+  risk set — M windows give M independent denominators of size N, never one of size M·N.
+
+Decision: **implement Lever 1 only**, one `optimizer.step()` per window. Since memory
+is cheap, just raise N directly. Lever 2 is deferred — it only earns its keep if we hit
+a memory wall, can't raise N further, and still want lower-variance steps.
+
+### 7. Learning rate / schedule consequence
+
+With one optimizer step per N patients, there are ~N× fewer updates per epoch than the
+per-patient NLL path. Budget for a **higher LR and/or more epochs** in the sweep, or
+training will appear to stall.
+
+## Codebase touch points
+
+- `src/utils/train_utils.py::LossFactory` — add a Cox branch (currently maps
+  `task == "survival"` → `NLLSurvLoss`). Decide Cox selection via a config field
+  (e.g. `survival.loss: coxph`) rather than overloading `task`.
+- `src/utils/survival_utils.py::train` — add the prediction-accumulation loop for the
+  Cox path (the current loop does per-patient NLL with optional gradient accumulation).
+- `src/utils/survival_utils.py::tune` / `inference` — add the full-cohort Cox eval path
+  (replace `-sum(surv)` risk with raw output; compute full-cohort Cox loss).
+- Model construction (`ModelFactory`) — `num_classes = 1` for Cox.
+- Dataset already yields `(idx, x, label, event_time, censored)`; Cox consumes
+  `event_time` and `1 - censored` directly and **ignores the discrete `label` bin**.
+- New custom `BatchSampler` for event-balanced windows.
+- `requirements` — add `torchsurv==0.1.6`.
+- `src/utils/metrics.py` — no change to `concordance_index_censored`; just ensure the
+  Cox caller passes raw risk.
+
+## Suggested config
+
+```yaml
+survival:
+  loss: coxph              # selects the Cox path; default stays nll
+  cox:
+    n: 48                  # prediction-accumulation window size = risk-set size
+    ties: breslow          # or efron (torchsurv flag)
+    event_balanced: true   # guarantee >= 1 event per window
+    min_events_per_window: 1
+batch_size: 1
+```
+
+Adapt names to the existing config structure.
+
+## Open items (sweep, not blockers)
+
+- **N**: 32–64 candidates; depends on cohort size and memory headroom.
+- **Tie method**: Breslow if event times are granular (days) with few ties; Efron if
+  coarse (months/years) with heavy ties.
+- **Censoring rate**: drives how aggressive the event-balanced sampler must be.
+
+## Loss math reference (informational — implemented by torchsurv)
+
+For the no-ties case the Breslow partial likelihood is: sort by descending time, take
+`logcumsumexp` over sorted risks (the cumulative term at position *i* equals the
+log-sum-exp over all patients with time ≥ time_i, i.e. the risk set), and for event
+patients minimize `-(risk_i - logcumsumexp_i)`, averaged over events. We rely on
+`torchsurv` for this plus Efron tie handling; we do not reimplement it.
+
+## Tests to add
+
+1. **Graph connectivity** — after N forwards + one Cox `backward()`, model params have
+   non-zero gradients.
+2. **No-detach** — accumulated risks satisfy `requires_grad` and `grad_fn is not None`
+   before the loss.
+3. **Polarity** — a toy cohort where higher risk on early-event patients yields lower
+   loss than the reversed assignment (guards the `event = 1 - censored` mapping and the
+   C-index sign together).
+4. **Event-balanced sampler** — every emitted window contains ≥ `min_events_per_window`
+   events; no window is ever empty of events.
+5. **Full-cohort eval** — eval risk equals the raw model output and the eval Cox loss is
+   computed once over all patients (not windowed).
+
+## Acceptance criteria
+
+1. Can train a variable-size MIL survival model with `batch_size=1`, Cox loss, and
+   `n > 1`, with the NLL path unchanged.
+2. Cox loss is computed once per window (one optimizer step per window).
+3. Risk tensors stay graph-connected until the loss is computed.
+4. Every training window contains at least one event (event-balanced sampler).
+5. Eval computes a single full-cohort Cox loss and uses raw risk for the C-index.
+6. Tests cover graph connectivity, no-detach, polarity/sign, sampler guarantees, and
+   full-cohort eval.
+7. Compatible with the existing training-loop style and config system.
+```

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ torch==1.13.1
 torchvision==0.14.1
 scikit-learn
 scikit-survival
+torchsurv==0.1.6
 tqdm
 wholeslidedata<0.0.16
 opencv-python

--- a/src/configs/default.yaml
+++ b/src/configs/default.yaml
@@ -7,6 +7,14 @@ output_dir: "output" # output directory
 
 task: "classification" # task type: classification, regression, survival
 
+survival:
+  loss: "nll" # survival loss: "nll" (discrete-time) or "coxph" (continuous-time)
+  cox:
+    n: 48 # prediction-accumulation window size = Cox risk-set size
+    ties: "breslow" # tie handling passed to torchsurv: "breslow" or "efron"
+    event_balanced: true # guarantee at least min_events events per window
+    min_events: 1 # minimum number of events per accumulation window
+
 num_classes: 6 # number of classes for classification task
 label_name: "label"
 label_mapping:

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -65,9 +65,14 @@ class ExtractedFeaturesSurvivalDataset(ExtractedFeaturesDataset):
         self.seed = self.options.seed
 
         self.df = self.prepare_data(self.options.df)
-        self.num_classes = len(
-            self.options.df.discrete_label.value_counts(dropna=True)
-        )
+        # discrete_label is only needed by the NLL path; the Cox path uses raw
+        # event_time / censored and ignores it
+        if "discrete_label" in self.options.df.columns:
+            self.num_classes = len(
+                self.options.df.discrete_label.value_counts(dropna=True)
+            )
+        else:
+            self.num_classes = 1
 
     def __getitem__(self, idx: int):
         row = self.df.loc[idx]
@@ -78,5 +83,5 @@ class ExtractedFeaturesSurvivalDataset(ExtractedFeaturesDataset):
         fp = Path(self.options.features_dir, f"{case_id}.pt")
         feature = torch.load(fp, map_location='cpu')
 
-        label = row.discrete_label
+        label = row.discrete_label if "discrete_label" in self.df.columns else -1
         return idx, feature, label, event_time, censored

--- a/src/train/survival-multi.py
+++ b/src/train/survival-multi.py
@@ -21,10 +21,15 @@ from src.utils import (
     SchedulerFactory,
     compute_time,
 )
-from src.utils import inference_survival as inference
+from src.utils import (
+    inference_survival,
+    inference_coxph,
+    train_survival,
+    train_coxph,
+    tune_survival,
+    tune_coxph,
+)
 from src.utils import setup
-from src.utils import train_survival as train
-from src.utils import tune_survival as tune
 from src.utils import update_log_dict
 
 
@@ -65,6 +70,12 @@ def main(args):
     num_workers = min(mp.cpu_count(), cfg.speed.num_workers)
     if "SLURM_JOB_CPUS_PER_NODE" in os.environ:
         num_workers = min(num_workers, int(os.environ["SLURM_JOB_CPUS_PER_NODE"]))
+
+    is_cox = cfg.survival.loss == "coxph"
+    if is_cox:
+        train, tune, inference = train_coxph, tune_coxph, inference_coxph
+    else:
+        train, tune, inference = train_survival, tune_survival, inference_survival
 
     fold_root_dir = Path(cfg.data.fold_dir)
     nfold = len([_ for _ in fold_root_dir.glob("fold*")])
@@ -124,19 +135,28 @@ def main(args):
         if test_df is not None:
             test_dataset = ExtractedFeaturesSurvivalDataset(test_dataset_options)
 
-        m, n = train_dataset.num_classes, tune_dataset.num_classes
-        assert (
-            m == n == cfg.num_classes
-        ), f"Either train (C={m}) or tune (C={n}) sets doesnt cover full class spectrum (C={cfg.num_classes})"
+        if is_cox:
+            # Cox uses a single risk scalar head; discrete bins are irrelevant
+            num_classes = 1
+        else:
+            m, n = train_dataset.num_classes, tune_dataset.num_classes
+            assert (
+                m == n == cfg.num_classes
+            ), f"Either train (C={m}) or tune (C={n}) sets doesnt cover full class spectrum (C={cfg.num_classes})"
+            num_classes = cfg.num_classes
 
-        criterion = LossFactory(cfg.task).get_loss()
+        criterion = LossFactory(
+            cfg.task,
+            survival_loss=cfg.survival.loss,
+            cox_ties=cfg.survival.cox.ties,
+        ).get_loss()
 
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         print("Initializing model")
         model = ModelFactory(
             level=cfg.model.level,
-            num_classes=cfg.num_classes,
+            num_classes=num_classes,
             options=cfg.model,
         ).get_model()
         model.to(device)
@@ -180,18 +200,33 @@ def main(args):
                 if cfg.wandb.enable:
                     log_dict = {f"train/fold_{i}/epoch": epoch + 1}
 
-                train_results = train(
-                    epoch + 1,
-                    model,
-                    train_dataset,
-                    optimizer,
-                    criterion,
-                    metric_names=cfg.metrics,
-                    batch_size=cfg.training.batch_size,
-                    gradient_accumulation=cfg.training.gradient_accumulation,
-                    num_workers=num_workers,
-                    device=device,
-                )
+                if is_cox:
+                    train_results = train(
+                        epoch + 1,
+                        model,
+                        train_dataset,
+                        optimizer,
+                        criterion,
+                        metric_names=cfg.metrics,
+                        n=cfg.survival.cox.n,
+                        event_balanced=cfg.survival.cox.event_balanced,
+                        min_events=cfg.survival.cox.min_events,
+                        num_workers=num_workers,
+                        device=device,
+                    )
+                else:
+                    train_results = train(
+                        epoch + 1,
+                        model,
+                        train_dataset,
+                        optimizer,
+                        criterion,
+                        metric_names=cfg.metrics,
+                        batch_size=cfg.training.batch_size,
+                        gradient_accumulation=cfg.training.gradient_accumulation,
+                        num_workers=num_workers,
+                        device=device,
+                    )
 
                 if cfg.wandb.enable:
                     update_log_dict(f"train/fold_{i}", train_results, log_dict, step=f"train/fold_{i}/epoch")

--- a/src/train/survival.py
+++ b/src/train/survival.py
@@ -18,10 +18,15 @@ from src.utils import (
     SchedulerFactory,
     compute_time,
 )
-from src.utils import inference_survival as inference
+from src.utils import (
+    inference_survival,
+    inference_coxph,
+    train_survival,
+    train_coxph,
+    tune_survival,
+    tune_coxph,
+)
 from src.utils import setup
-from src.utils import train_survival as train
-from src.utils import tune_survival as tune
 from src.utils import update_log_dict
 
 
@@ -95,19 +100,35 @@ def main(args):
     if cfg.data.test_csv:
         test_dataset = ExtractedFeaturesSurvivalDataset(test_dataset_options)
 
-    m, n = train_dataset.num_classes, tune_dataset.num_classes
-    assert (
-        m == n == cfg.num_classes
-    ), f"Either train (C={m}) or tune (C={n}) sets doesnt cover full class spectrum (C={cfg.num_classes})"
+    is_cox = cfg.survival.loss == "coxph"
+    if is_cox:
+        # Cox uses a single risk scalar head; the discrete bin spectrum is irrelevant
+        num_classes = 1
+        train = train_coxph
+        tune = tune_coxph
+        inference = inference_coxph
+    else:
+        m, n = train_dataset.num_classes, tune_dataset.num_classes
+        assert (
+            m == n == cfg.num_classes
+        ), f"Either train (C={m}) or tune (C={n}) sets doesnt cover full class spectrum (C={cfg.num_classes})"
+        num_classes = cfg.num_classes
+        train = train_survival
+        tune = tune_survival
+        inference = inference_survival
 
-    criterion = LossFactory(cfg.task).get_loss()
+    criterion = LossFactory(
+        cfg.task,
+        survival_loss=cfg.survival.loss,
+        cox_ties=cfg.survival.cox.ties,
+    ).get_loss()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     print("Initializing model")
     model = ModelFactory(
         level=cfg.model.level,
-        num_classes=cfg.num_classes,
+        num_classes=num_classes,
         options=cfg.model,
     ).get_model()
     model.to(device)
@@ -148,18 +169,33 @@ def main(args):
             if cfg.wandb.enable:
                 log_dict = {"epoch": epoch + 1}
 
-            train_results = train(
-                epoch + 1,
-                model,
-                train_dataset,
-                optimizer,
-                criterion,
-                metric_names=cfg.metrics,
-                batch_size=cfg.training.batch_size,
-                gradient_accumulation=cfg.training.gradient_accumulation,
-                num_workers=num_workers,
-                device=device,
-            )
+            if is_cox:
+                train_results = train(
+                    epoch + 1,
+                    model,
+                    train_dataset,
+                    optimizer,
+                    criterion,
+                    metric_names=cfg.metrics,
+                    n=cfg.survival.cox.n,
+                    event_balanced=cfg.survival.cox.event_balanced,
+                    min_events=cfg.survival.cox.min_events,
+                    num_workers=num_workers,
+                    device=device,
+                )
+            else:
+                train_results = train(
+                    epoch + 1,
+                    model,
+                    train_dataset,
+                    optimizer,
+                    criterion,
+                    metric_names=cfg.metrics,
+                    batch_size=cfg.training.batch_size,
+                    gradient_accumulation=cfg.training.gradient_accumulation,
+                    num_workers=num_workers,
+                    device=device,
+                )
 
             if cfg.wandb.enable:
                 update_log_dict("train", train_results, log_dict)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -27,4 +27,7 @@ from .survival_utils import (
     train as train_survival,
     tune as tune_survival,
     inference as inference_survival,
+    train_coxph,
+    tune_coxph,
+    inference_coxph,
 )

--- a/src/utils/loss.py
+++ b/src/utils/loss.py
@@ -55,3 +55,28 @@ class NLLSurvLoss(object):
             return nll_loss(hazards, S, label, c, alpha=self.alpha)
         else:
             return nll_loss(hazards, S, label, c, alpha=alpha)
+
+
+class CoxSurvLoss(object):
+    """Continuous-time Cox partial-likelihood loss.
+
+    Thin wrapper around torchsurv so we don't reimplement sorting / tie handling.
+    Expects raw risk scores (higher = higher hazard = shorter survival), the
+    observed/censoring time, and the dataset `censored` indicator (1 = censored).
+    """
+
+    def __init__(self, ties: str = "breslow"):
+        self.ties = ties
+
+    def __call__(self, risks, event_time, censored):
+        # imported lazily so the dependency is only required for the Cox path
+        from torchsurv.loss.cox import neg_partial_log_likelihood
+
+        # compute in float32 for numerical stability of the log-cumsum term
+        risks = risks.float().view(-1)
+        # dataset uses censored (1 = censored); torchsurv wants event (1 = event)
+        event = (1.0 - censored.float().view(-1)).bool()
+        time = event_time.float().view(-1)
+        return neg_partial_log_likelihood(
+            risks, event, time, ties_method=self.ties, reduction="mean"
+        )

--- a/src/utils/survival_utils.py
+++ b/src/utils/survival_utils.py
@@ -6,7 +6,7 @@ from functools import partial
 from collections.abc import Callable
 
 from src.utils.metrics import get_metrics
-from src.utils.train_utils import collate_features_survival
+from src.utils.train_utils import collate_features_survival, EventBalancedSampler
 
 
 def train(
@@ -245,3 +245,233 @@ def inference(
     results.update(metrics)
 
     return results
+
+
+def train_coxph(
+    epoch: int,
+    model: nn.Module,
+    dataset: torch.utils.data.Dataset,
+    optimizer: torch.optim.Optimizer,
+    criterion: Callable,
+    metric_names: list[str],
+    n: int = 48,
+    event_balanced: bool = True,
+    min_events: int = 1,
+    collate_fn: Callable = partial(collate_features_survival, label_type="int"),
+    num_workers: int = 0,
+    device: torch.device | None = None,
+):
+    """Cox training with prediction accumulation.
+
+    Each window forwards ``n`` single-patient bags one at a time, keeps their
+    graph-connected risk scalars, computes one Cox loss over the window, and
+    backpropagates once. See cox-ph-trick.md for the rationale.
+    """
+
+    model.train()
+    epoch_loss = 0.0
+    num_windows = 0
+    censoring, event_times, risk_scores = [], [], []
+    idxs = []
+
+    n_events = int((dataset.df.censored.values == 0).sum())
+    if event_balanced:
+        sampler = EventBalancedSampler(
+            dataset.df.censored.values, n=n, min_events=min_events, seed=epoch
+        )
+        if sampler.num_windows == 0:
+            raise ValueError(
+                f"cox.n={n} (min_events={min_events}) yields 0 windows for "
+                f"{len(dataset)} patients / {n_events} events. "
+                f"Lower cox.n or cox.min_events."
+            )
+    else:
+        if len(dataset) < n:
+            raise ValueError(
+                f"cox.n={n} exceeds dataset size ({len(dataset)}); no window can "
+                f"be filled. Lower cox.n."
+            )
+        sampler = torch.utils.data.RandomSampler(dataset)
+
+    loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=1,
+        sampler=sampler,
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+    )
+
+    results = {}
+
+    risk_buffer, time_buffer, cens_buffer = [], [], []
+
+    def flush():
+        nonlocal epoch_loss, num_windows
+        if len(risk_buffer) == 0:
+            return
+        risks = torch.cat(risk_buffer, dim=0).view(-1)
+        times = torch.cat(time_buffer, dim=0).view(-1)
+        cens = torch.cat(cens_buffer, dim=0).view(-1)
+
+        loss = criterion(risks, times, cens)
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+
+        epoch_loss += loss.item()
+        num_windows += 1
+        risk_buffer.clear()
+        time_buffer.clear()
+        cens_buffer.clear()
+
+    with tqdm.tqdm(
+        loader,
+        desc=(f"Epoch {epoch} - Train"),
+        unit=" case",
+        leave=False,
+    ) as t:
+        for batch in t:
+            idx, x, _, event_time, censored = batch
+            x = x.to(device, non_blocking=True)
+            event_time = event_time.to(device, non_blocking=True)
+            censored = censored.to(device, non_blocking=True)
+
+            risk = model(x).view(1)  # [1], raw scalar = log relative hazard
+
+            risk_buffer.append(risk)
+            time_buffer.append(event_time.view(1))
+            cens_buffer.append(censored.view(1))
+
+            risk_scores.append(risk.item())
+            censoring.append(censored.item())
+            event_times.append(event_time.item())
+            idxs.extend(list(idx))
+
+            if len(risk_buffer) == n:
+                flush()
+
+    # the event-balanced sampler yields a multiple of n, so nothing is left over;
+    # under random sampling we drop the trailing partial window (no event guarantee)
+    risk_buffer.clear()
+    time_buffer.clear()
+    cens_buffer.clear()
+
+    assert len(idxs) == len(set(idxs)), "idxs must be unique"
+    dataset.df.loc[idxs, "risk"] = risk_scores
+
+    event_indicator = [bool(1 - c) for c in censoring]
+    metrics = get_metrics(
+        metric_names,
+        risk_scores,
+        event_times,
+        event_indicator=event_indicator,
+    )
+    results.update(metrics)
+
+    results["loss"] = epoch_loss / max(num_windows, 1)
+    return results
+
+
+def _coxph_eval(
+    model: nn.Module,
+    dataset: torch.utils.data.Dataset,
+    metric_names: list[str],
+    criterion: Callable | None = None,
+    desc: str = "Tune",
+    epoch: int | None = None,
+    collate_fn: Callable = partial(collate_features_survival, label_type="int"),
+    num_workers: int = 0,
+    device: torch.device | None = None,
+):
+    """Shared Cox evaluation: collect raw risks over the full cohort under no_grad,
+    then compute one Cox loss over the entire cohort (the true full risk set)."""
+
+    model.eval()
+    censoring, event_times, risk_scores = [], [], []
+    idxs = []
+
+    loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=1,
+        sampler=torch.utils.data.SequentialSampler(dataset),
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+    )
+
+    label = f"Epoch {epoch} - {desc}" if epoch is not None else desc
+    with tqdm.tqdm(loader, desc=label, unit=" case", leave=(epoch is None)) as t:
+        with torch.no_grad():
+            for batch in t:
+                idx, x, _, event_time, censored = batch
+                x = x.to(device, non_blocking=True)
+
+                risk = model(x).view(1)
+                risk_scores.append(risk.item())
+                censoring.append(censored.item())
+                event_times.append(event_time.item())
+                idxs.extend(list(idx))
+
+    assert len(idxs) == len(set(idxs)), "idxs must be unique"
+    dataset.df.loc[idxs, "risk"] = risk_scores
+
+    event_indicator = [bool(1 - c) for c in censoring]
+    results = get_metrics(
+        metric_names,
+        risk_scores,
+        event_times,
+        event_indicator=event_indicator,
+    )
+
+    if criterion is not None:
+        risks = torch.tensor(risk_scores, dtype=torch.float32, device=device)
+        times = torch.tensor(event_times, dtype=torch.float32, device=device)
+        cens = torch.tensor(censoring, dtype=torch.float32, device=device)
+        results["loss"] = criterion(risks, times, cens).item()
+
+    return results
+
+
+def tune_coxph(
+    epoch: int,
+    model: nn.Module,
+    dataset: torch.utils.data.Dataset,
+    criterion: Callable,
+    metric_names: list[str],
+    batch_size: int = 1,  # ignored: eval is always sequential, one bag at a time
+    collate_fn: Callable = partial(collate_features_survival, label_type="int"),
+    num_workers: int = 0,
+    device: torch.device | None = None,
+):
+    return _coxph_eval(
+        model,
+        dataset,
+        metric_names,
+        criterion=criterion,
+        desc="Tune",
+        epoch=epoch,
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+        device=device,
+    )
+
+
+def inference_coxph(
+    model: nn.Module,
+    dataset: torch.utils.data.Dataset,
+    metric_names: list[str],
+    batch_size: int = 1,  # ignored: eval is always sequential, one bag at a time
+    collate_fn: Callable = partial(collate_features_survival, label_type="int"),
+    num_workers: int = 0,
+    device: torch.device | None = None,
+):
+    return _coxph_eval(
+        model,
+        dataset,
+        metric_names,
+        criterion=None,
+        desc="Inference",
+        epoch=None,
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+        device=device,
+    )

--- a/src/utils/train_utils.py
+++ b/src/utils/train_utils.py
@@ -1,9 +1,10 @@
+import numpy as np
 import torch
 import torch.nn as nn
 
 from pathlib import Path
 
-from src.utils.loss import NLLSurvLoss
+from src.utils.loss import NLLSurvLoss, CoxSurvLoss
 
 
 def collate_features(batch, label_type: str = "int"):
@@ -34,16 +35,94 @@ class LossFactory:
     def __init__(
         self,
         task: str,
+        survival_loss: str = "nll",
+        cox_ties: str = "breslow",
     ):
         if task == "classification":
             self.criterion = nn.CrossEntropyLoss()
         elif task == "regression":
             self.criterion = nn.MSELoss()
         elif task == "survival":
-            self.criterion = NLLSurvLoss()
+            if survival_loss == "coxph":
+                self.criterion = CoxSurvLoss(ties=cox_ties)
+            else:
+                self.criterion = NLLSurvLoss()
 
     def get_loss(self):
         return self.criterion
+
+
+class EventBalancedSampler(torch.utils.data.Sampler):
+    """Flat index sampler whose every consecutive block of ``n`` indices contains
+    at least ``min_events`` events.
+
+    Bags are forwarded one at a time (batch_size=1), so this orders the *flat*
+    stream of indices rather than returning batches. The Cox training loop slices
+    the stream into windows of size ``n``; this sampler guarantees each window has
+    events (a Cox loss needs >= 1 event to produce a gradient). It also drops the
+    trailing partial window, so ``len`` is always a multiple of ``n``.
+
+    This changes how patients are *grouped*, not which patients are seen: every
+    event and censored patient is placed exactly once per epoch (up to the dropped
+    remainder).
+    """
+
+    def __init__(
+        self,
+        censored,
+        n: int,
+        min_events: int = 1,
+        seed: int = 0,
+    ):
+        censored = torch.as_tensor(np.asarray(censored).copy()).view(-1)
+        self.event_idxs = torch.nonzero(censored == 0, as_tuple=False).view(-1).tolist()
+        self.censored_idxs = torch.nonzero(censored == 1, as_tuple=False).view(-1).tolist()
+        self.n = n
+        self.min_events = max(1, min_events)
+        self.seed = seed
+
+        n_total = len(self.event_idxs) + len(self.censored_idxs)
+        n_windows = n_total // n
+        # cap by how many windows we can give >= min_events events
+        n_windows = min(n_windows, len(self.event_idxs) // self.min_events)
+        self.num_windows = max(0, n_windows)
+
+    def set_epoch(self, epoch: int):
+        self.seed = epoch
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self.seed)
+
+        def shuffled(items):
+            perm = torch.randperm(len(items), generator=g).tolist()
+            return [items[i] for i in perm]
+
+        events = shuffled(self.event_idxs)
+        censored = shuffled(self.censored_idxs)
+
+        windows = [[] for _ in range(self.num_windows)]
+        ei = 0
+        # deal min_events events into each window first
+        for w in range(self.num_windows):
+            for _ in range(self.min_events):
+                windows[w].append(events[ei])
+                ei += 1
+        # fill the rest from the leftover events + all censored patients
+        pool = shuffled(events[ei:] + censored)
+        pi = 0
+        for w in range(self.num_windows):
+            while len(windows[w]) < self.n and pi < len(pool):
+                windows[w].append(pool[pi])
+                pi += 1
+
+        flat = []
+        for w in windows:
+            flat.extend(w)
+        return iter(flat)
+
+    def __len__(self):
+        return self.num_windows * self.n
 
 
 class OptimizerFactory:

--- a/tests/test_coxph.py
+++ b/tests/test_coxph.py
@@ -1,0 +1,107 @@
+"""Unit tests for the CoxPH prediction-accumulation training path.
+
+Run with: pytest tests/test_coxph.py
+"""
+
+import torch
+import torch.nn as nn
+
+from src.utils.loss import CoxSurvLoss
+from src.utils.train_utils import EventBalancedSampler
+
+
+def _toy_model():
+    # maps a variable-size bag [1, k, d] to a single risk scalar [1, 1]
+    return nn.Sequential(
+        nn.Linear(4, 1),
+    )
+
+
+def _bag(k):
+    return torch.randn(k, 4)
+
+
+def test_graph_connectivity_and_no_detach():
+    """Params receive non-zero gradients after N forwards + one Cox loss backward,
+    and accumulated risks stay graph-connected until the loss."""
+    torch.manual_seed(0)
+    head = _toy_model()
+
+    risk_buffer = []
+    for k in (3, 7, 5, 2):  # variable-size bags
+        pooled = head(_bag(k)).mean(dim=0)  # [1] raw risk scalar
+        risk_buffer.append(pooled.view(1))
+
+    risks = torch.cat(risk_buffer, dim=0)
+    # no-detach: accumulated risks must still be connected to the graph
+    assert risks.requires_grad
+    assert risks.grad_fn is not None
+
+    times = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    censored = torch.tensor([0.0, 0.0, 1.0, 1.0])  # first two are events
+
+    loss = CoxSurvLoss(ties="breslow")(risks, times, censored)
+    loss.backward()
+
+    grads = [p.grad for p in head.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    assert any(torch.any(g != 0) for g in grads)
+
+
+def test_cox_loss_polarity():
+    """Event patients with higher predicted risk should give lower loss than the
+    reversed assignment. Also guards the censored -> event mapping."""
+    times = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    censored = torch.tensor([0.0, 0.0, 1.0, 1.0])  # early patients are events
+
+    good = torch.tensor([4.0, 3.0, 2.0, 1.0])  # high risk for early-event
+    bad = torch.tensor([1.0, 2.0, 3.0, 4.0])  # reversed
+
+    loss = CoxSurvLoss(ties="breslow")
+    assert loss(good, times, censored).item() < loss(bad, times, censored).item()
+
+
+def test_event_balanced_sampler_guarantees_events():
+    """Every emitted window contains >= min_events events, the length is a multiple
+    of n, and no index is duplicated within an epoch."""
+    n = 8
+    min_events = 2
+    # 40 patients, 12 events (event = censored 0)
+    censored = torch.ones(40)
+    censored[:12] = 0.0
+    event_set = set(range(12))
+
+    sampler = EventBalancedSampler(censored, n=n, min_events=min_events, seed=1)
+    flat = list(iter(sampler))
+
+    assert len(flat) == len(sampler)
+    assert len(flat) % n == 0
+    assert len(flat) == len(set(flat)), "indices must not repeat within an epoch"
+
+    for w in range(0, len(flat), n):
+        window = flat[w : w + n]
+        n_events = sum(1 for i in window if i in event_set)
+        assert n_events >= min_events
+
+
+def test_event_balanced_sampler_reseeds_per_epoch():
+    censored = torch.ones(40)
+    censored[:12] = 0.0
+    sampler = EventBalancedSampler(censored, n=8, min_events=1, seed=0)
+
+    sampler.set_epoch(0)
+    order_a = list(iter(sampler))
+    sampler.set_epoch(1)
+    order_b = list(iter(sampler))
+
+    assert order_a != order_b, "different epochs should produce different windows"
+
+
+def test_full_cohort_eval_loss_is_scalar():
+    """The eval Cox loss is computed once over the whole cohort, not per window."""
+    torch.manual_seed(0)
+    risks = torch.randn(50)
+    times = torch.rand(50) * 10
+    censored = (torch.rand(50) > 0.5).float()
+    loss = CoxSurvLoss(ties="breslow")(risks, times, censored)
+    assert loss.dim() == 0  # single scalar over the full cohort


### PR DESCRIPTION
## What

Adds an **opt-in continuous-time CoxPH** survival training path alongside the existing discrete-time NLL path.

MIL bags are variable-size and forwarded one at a time (`batch_size=1`). Standard gradient accumulation can't form a Cox risk set (each microbatch is one patient), so this accumulates **graph-connected** risk scalars across `N` single-bag forwards, computes **one** Cox loss over the window, and backprops once.

## How it works

- **`CoxSurvLoss`** — thin wrapper over [`torchsurv`](https://pypi.org/project/torchsurv/) (`event = 1 - censored`, computed in fp32, Breslow/Efron tie handling). No hand-rolled partial likelihood.
- **`EventBalancedSampler`** — orders the flat index stream so every window of `N` contains ≥ `min_events` events (a Cox loss needs ≥1 event), drops the trailing partial window, reseeds per epoch.
- **`train_coxph`** — prediction-accumulation loop, one optimizer step per window, with a clear guard when `cox.n` is too large for the cohort.
- **`tune_coxph` / `inference_coxph`** — eval runs under `no_grad` and computes the Cox loss over the **full cohort** (true risk set, deterministic across epochs → clean early-stopping signal). Raw model output is the risk.
- Cox head uses `num_classes=1`; `discrete_label` made optional in the dataset.
- Wired into **both** `survival.py` and `survival-multi.py`.

## Config

```yaml
survival:
  loss: coxph          # default stays "nll"
  cox:
    n: 48              # prediction-accumulation window = risk-set size
    ties: breslow      # or efron
    event_balanced: true
    min_events: 1
```

Example config: `config/training/survival/coxph.yaml`. New dependency: `torchsurv==0.1.6`.

## Notes for tuning

One optimizer step per `N` patients ⇒ ~`N`× fewer updates/epoch than NLL — budget a higher LR and/or more epochs. Pick `ties=efron` if event times are coarse (months/years) with heavy ties.

## Tests

`tests/test_coxph.py`: graph connectivity, no-detach, loss polarity + C-index sign, sampler event guarantees, full-cohort eval (these use a lightweight stand-in model).

Additionally verified **end-to-end through `train_coxph` / `tune_coxph` / `inference_coxph` on the real `LocalHIPT(num_classes=1)`** (the primary aggregator) with variable-size bags running through the actual region-ViT: single forward yields `[1, 1]`, the accumulation loop steps, full-cohort eval runs, and the risk column is written. `GlobalHIPT(num_classes=1)` head shape / gradient flow was also checked.
